### PR TITLE
Improve dotfiles deploy

### DIFF
--- a/scripts/deploy_dotfiles.sh
+++ b/scripts/deploy_dotfiles.sh
@@ -21,9 +21,9 @@ _CMD="( \
     && export DOTFILES_LOCAL=${DOTFILES_LOCAL:-~/.dot.local.toml} \
     && curl -fsSL https://raw.githubusercontent.com/MamoruDS/dotfiles/main/install.sh | sh \
     && echo '[ -f ~/.zshrc.dot ] && . ~/.zshrc.dot' >> ~/.zshrc \
-    && if [ -n \$DOTTER_BIN_DIR ] && echo 'DOTTER_BIN_DIR=\$DOTTER_BIN_DIR' >> ~/.zshrc \
-    && if [ -n \$DOTFILES_ROOT ] && echo 'DOTFILES_ROOT=\$DOTFILES_ROOT' >> ~/.zshrc \
-    && if [ -n \$DOTFILES_LOCAL ] && echo 'DOTTER_BIN_DIR=\$DOTFILES_LOCAL' >> ~/.zshrc
+    && if [ -n \"\$DOTTER_BIN_DIR\" ]; then echo \"DOTTER_BIN_DIR=\$DOTTER_BIN_DIR\" >> ~/.zshrc ; fi \
+    && if [ -n \"\$DOTFILES_ROOT\" ]; then echo \"DOTFILES_ROOT=\$DOTFILES_ROOT\" >> ~/.zshrc ; fi \
+    && if [ -n \"\$DOTFILES_LOCAL\" ]; then echo \"DOTFILES_LOCAL=\$DOTFILES_LOCAL\" >> ~/.zshrc ; fi
 )"
 
 target_user="$1"

--- a/scripts/deploy_dotfiles.sh
+++ b/scripts/deploy_dotfiles.sh
@@ -17,13 +17,14 @@ if ! [ -x "$(command -v git)" ]; then
     panic "git is not installed"
 fi
 
+_DEPLOY_SCRIPT_URL=${DOTFILES_DEPLOY_SCRIPT_URL:-'https://raw.githubusercontent.com/MamoruDS/dotfiles/main/install.sh'}
 _CMD="( \
     cd ~ \
     && export DOTFILES_PACKAGES=$DOTFILES_PACKAGES \
     && export DOTTER_BIN_DIR=$DOTTER_BIN_DIR \
     && export DOTFILES_ROOT=$DOTFILES_ROOT \
     && export DOTFILES_LOCAL=${DOTFILES_LOCAL:-~/.dot.local.toml} \
-    && curl -fsSL https://raw.githubusercontent.com/MamoruDS/dotfiles/main/install.sh | sh \
+    && curl -fsSL ${_DEPLOY_SCRIPT_URL} | sh \
     && echo '[ -f ~/.zshrc.dot ] && . ~/.zshrc.dot' >> ~/.zshrc \
     && if [ -n \"\$DOTTER_BIN_DIR\" ]; then echo \"DOTTER_BIN_DIR=\$DOTTER_BIN_DIR\" >> ~/.zshrc ; fi \
     && if [ -n \"\$DOTFILES_ROOT\" ]; then echo \"DOTFILES_ROOT=\$DOTFILES_ROOT\" >> ~/.zshrc ; fi \

--- a/scripts/deploy_dotfiles.sh
+++ b/scripts/deploy_dotfiles.sh
@@ -24,11 +24,7 @@ _CMD="( \
     && export DOTTER_BIN_DIR=$DOTTER_BIN_DIR \
     && export DOTFILES_ROOT=$DOTFILES_ROOT \
     && export DOTFILES_LOCAL=${DOTFILES_LOCAL:-~/.dot.local.toml} \
-    && curl -fsSL ${_DEPLOY_SCRIPT_URL} | sh \
-    && echo '[ -f ~/.zshrc.dot ] && . ~/.zshrc.dot' >> ~/.zshrc \
-    && if [ -n \"\$DOTTER_BIN_DIR\" ]; then echo \"DOTTER_BIN_DIR=\$DOTTER_BIN_DIR\" >> ~/.zshrc ; fi \
-    && if [ -n \"\$DOTFILES_ROOT\" ]; then echo \"DOTFILES_ROOT=\$DOTFILES_ROOT\" >> ~/.zshrc ; fi \
-    && if [ -n \"\$DOTFILES_LOCAL\" ]; then echo \"DOTFILES_LOCAL=\$DOTFILES_LOCAL\" >> ~/.zshrc ; fi
+    && curl -fsSL ${_DEPLOY_SCRIPT_URL} | sh
 )"
 
 target_user="$1"

--- a/scripts/deploy_dotfiles.sh
+++ b/scripts/deploy_dotfiles.sh
@@ -23,7 +23,7 @@ _CMD="( \
     && export DOTFILES_PACKAGES=$DOTFILES_PACKAGES \
     && export DOTTER_BIN_DIR=$DOTTER_BIN_DIR \
     && export DOTFILES_ROOT=$DOTFILES_ROOT \
-    && export DOTFILES_LOCAL=${DOTFILES_LOCAL:-~/.dot.local.toml} \
+    && export DOTFILES_LOCAL=${DOTFILES_LOCAL:-'$HOME/.dot.local.toml'} \
     && curl -fsSL ${_DEPLOY_SCRIPT_URL} | sh
 )"
 

--- a/scripts/deploy_dotfiles.sh
+++ b/scripts/deploy_dotfiles.sh
@@ -1,16 +1,20 @@
 #!/bin/sh
 
-error() {
-    echo "Error: $1" >&2
+info() {
+    printf '%s\n' "Info: $*"
+}
+
+panic() {
+    printf '%s\n' "Error: $*" >&2
     exit 1
 }
 
 if ! [ -x "$(command -v curl)" ]; then
-    error "curl is not installed"
+    panic "curl is not installed"
 fi
 
 if ! [ -x "$(command -v git)" ]; then
-    error "git is not installed"
+    panic "git is not installed"
 fi
 
 _CMD="( \


### PR DESCRIPTION
Improve dotfiles deploy process:

-   [x] ~How dotfiles env vars write into user's `zshrc` is broken~
-   [x] Allow custom dotfiles repository
        Assign custom deploy script url with variable `DOTFILES_DEPLOY_SCRIPT_URL`
-   [ ] ~Deploy dotfiles only; do not setup `zshrc`~
        Shell related setup should be managed by (post) deploy script
