### PR TITLE
Matrix filter for `workspace-image-ci`

### DIFF
--- a/.github/workflows/ctr_workspace.yml
+++ b/.github/workflows/ctr_workspace.yml
@@ -49,6 +49,7 @@ jobs:
         steps:
             - uses: actions/checkout@v3
             - name: Login
+              if: ${{ !env.ACT }}
               uses: docker/login-action@v2
               with:
                   registry: ${{ env.REGISTRY }}
@@ -89,7 +90,7 @@ jobs:
                     echo "EOF" >> $GITHUB_ENV
                   fi
             - name: Build
-              if: ${{ !fromJSON(github.event.inputs.is_matrix_test) && env.EXTRA_TAGS }}
+              if: ${{ !env.ACT && !fromJSON(github.event.inputs.is_matrix_test) && env.EXTRA_TAGS }}
               uses: docker/build-push-action@v3
               with:
                   context: ./CTR_WORKSPACE

--- a/.github/workflows/ctr_workspace.yml
+++ b/.github/workflows/ctr_workspace.yml
@@ -13,6 +13,12 @@ on:
                 required: false
                 type: boolean
                 default: false
+            matrix_jq_selection:
+                description: jq select method expression used to filter the matrix
+                required: false
+                type: string
+                default: true
+
 env:
     # TOKEN: ${{ secrets.GITHUB_TOKEN }}
     TOKEN: ${{ secrets.PACKAGE_TOKEN }}
@@ -29,7 +35,12 @@ jobs:
               run: |
                   fp=./targets_matrix.json
                   if [ -e $fp ]; then
-                    echo "targets=$(cat $fp | jq -c)" >> $GITHUB_OUTPUT
+                    jq_sel='${{ github.event.inputs.matrix_jq_selection }}'
+                    if [ -z $jq_sel ]; then
+                      jq_sel='true'
+                    fi
+                    matrix=$(cat $fp | jq -c "{ include: [ .include[] | select($jq_sel) ] }")
+                    echo "targets=$matrix" >> $GITHUB_OUTPUT
                   else
                     echo "$fp not found"
                     exit 1

--- a/CTR_WORKSPACE/targets_matrix.json
+++ b/CTR_WORKSPACE/targets_matrix.json
@@ -20,6 +20,12 @@
     },
     {
       "dockerfile": "./CTR_WORKSPACE/ws.cuda.dockerfile",
+      "extra_tags": "11.0",
+      "cuda_version": "11.0.3",
+      "base_ubuntu": "20.04"
+    },
+    {
+      "dockerfile": "./CTR_WORKSPACE/ws.cuda.dockerfile",
       "extra_tags": "11.1",
       "cuda_version": "11.1.1",
       "base_ubuntu": "20.04"


### PR DESCRIPTION
- feat: filter `workspace-image-ci`'s matrix with inputs `matrix_jq_selection` e.g., `.cuda_version=="11.5"`
- add: new target nvidia/cuda 11.0.3 (11.0)
- update: skip docker related steps when runner is `act`
