### PR TITLE
PR: targets update

### DIFF
--- a/.github/workflows/ctr_workspace.yml
+++ b/.github/workflows/ctr_workspace.yml
@@ -1,113 +1,113 @@
 name: workspace-image-ci
 
 on:
-    workflow_dispatch:
-        inputs:
-            is_push_to_ghcr:
-                description: push after build
-                required: false
-                type: boolean
-                default: true
-            is_matrix_test:
-                description: only test the validity of matrix
-                required: false
-                type: boolean
-                default: false
-            matrix_jq_selection:
-                description: jq select method expression used to filter the matrix
-                required: false
-                type: string
-                default: true
+  workflow_dispatch:
+    inputs:
+      is_push_to_ghcr:
+        description: push after build
+        required: false
+        type: boolean
+        default: true
+      is_matrix_test:
+        description: only test the validity of matrix
+        required: false
+        type: boolean
+        default: false
+      matrix_jq_selection:
+        description: jq select method expression used to filter the matrix
+        required: false
+        type: string
+        default: true
 
 env:
-    # TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    TOKEN: ${{ secrets.PACKAGE_TOKEN }}
+  # TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  TOKEN: ${{ secrets.PACKAGE_TOKEN }}
 
 jobs:
-    load-targets:
-        runs-on: ubuntu-latest
-        outputs:
-            targets: ${{ steps.set-data.outputs.targets }}
-        steps:
-            - uses: actions/checkout@v3
-            - id: set-data
-              working-directory: ./CTR_WORKSPACE
-              run: |
-                  fp=./targets_matrix.json
-                  if [ -e $fp ]; then
-                    jq_sel='${{ github.event.inputs.matrix_jq_selection }}'
-                    if [ -z $jq_sel ]; then
-                      jq_sel='true'
-                    fi
-                    matrix=$(cat $fp | jq -c "{ include: [ .include[] | select($jq_sel) ] }")
-                    echo "targets=$matrix" >> $GITHUB_OUTPUT
-                  else
-                    echo "$fp not found"
-                    exit 1
-                  fi
-    build-and-push-to-ghcr:
-        needs: load-targets
-        runs-on: ubuntu-latest
-        strategy:
-            fail-fast: false
-            matrix: ${{ fromJSON(needs.load-targets.outputs.targets) }}
-        env:
-            REGISTRY: ghcr.io
-            IMAGE_NAME: workspace
-        outputs:
-            outputs1: ${{ github.repository_owner }}
-            outputs2: ${{ github.actor }}
-        steps:
-            - uses: actions/checkout@v3
-            - name: Login
-              if: ${{ !env.ACT }}
-              uses: docker/login-action@v2
-              with:
-                  registry: ${{ env.REGISTRY }}
-                  username: ${{ github.repository_owner }}
-                  password: ${{ env.TOKEN }}
-            - name: Downcase Repo
-              run: |
-                  echo "REPO=${GITHUB_REPOSITORY_OWNER,,}/${IMAGE_NAME,,}" >> ${GITHUB_ENV}
-            - name: Build tags for CUDA image
-              if: ${{ matrix.cuda_version }}
-              run: |
-                  SHA="${GITHUB_SHA::7}"
-                  IFS=,
-                  for tag in $(echo ${{ matrix.cuda_version }},${{ matrix.extra_tags }}); do
-                    if [ -n $tag ]; then
-                      echo "${REGISTRY}/${REPO}:cuda${tag}" >> .tags
-                      echo "${REGISTRY}/${REPO}:cuda${tag}.${SHA}" >> .tags
-                    fi
-                  done
-                  echo "EXTRA_TAGS<<EOF" >> $GITHUB_ENV
-                  cat .tags >> $GITHUB_ENV
-                  echo "EOF" >> $GITHUB_ENV
-            - name: Build tags for non-CUDA image
-              # matrix.extra_tags is required
-              if: ${{ !matrix.cuda_version }}
-              run: |
-                  SHA="${GITHUB_SHA::7}"
-                  IFS=,
-                  for tag in $(echo ${{ matrix.extra_tags }}); do
-                    if [ -n $tag ]; then
-                      echo "${REGISTRY}/${REPO}:${tag}" >> .tags
-                      echo "${REGISTRY}/${REPO}:${tag}.${SHA}" >> .tags
-                    fi
-                  done
-                  if [ -f .tags ]; then
-                    echo "EXTRA_TAGS<<EOF" >> $GITHUB_ENV
-                    cat .tags >> $GITHUB_ENV
-                    echo "EOF" >> $GITHUB_ENV
-                  fi
-            - name: Build
-              if: ${{ !env.ACT && !fromJSON(github.event.inputs.is_matrix_test) && env.EXTRA_TAGS }}
-              uses: docker/build-push-action@v3
-              with:
-                  context: ./CTR_WORKSPACE
-                  file: ${{ matrix.dockerfile }}
-                  push: ${{ fromJSON(github.event.inputs.is_push_to_ghcr) }}
-                  tags: ${{ env.EXTRA_TAGS }}
-                  build-args: |
-                      BASE_UBUNTU=${{ matrix.base_ubuntu }}
-                      CUDA_VER=${{ matrix.cuda_version }}
+  load-targets:
+    runs-on: ubuntu-latest
+    outputs:
+      targets: ${{ steps.set-data.outputs.targets }}
+    steps:
+      - uses: actions/checkout@v3
+      - id: set-data
+        working-directory: ./CTR_WORKSPACE
+        run: |
+          fp=./targets_matrix.json
+          if [ -e $fp ]; then
+            jq_sel='${{ github.event.inputs.matrix_jq_selection }}'
+            if [ -z $jq_sel ]; then
+              jq_sel='true'
+            fi
+            matrix=$(cat $fp | jq -c "{ include: [ .include[] | select($jq_sel) ] }")
+            echo "targets=$matrix" >> $GITHUB_OUTPUT
+          else
+            echo "$fp not found"
+            exit 1
+          fi
+  build-and-push-to-ghcr:
+    needs: load-targets
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.load-targets.outputs.targets) }}
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: workspace
+    outputs:
+      outputs1: ${{ github.repository_owner }}
+      outputs2: ${{ github.actor }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Login
+        if: ${{ !env.ACT }}
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ env.TOKEN }}
+      - name: Downcase Repo
+        run: |
+          echo "REPO=${GITHUB_REPOSITORY_OWNER,,}/${IMAGE_NAME,,}" >> ${GITHUB_ENV}
+      - name: Build tags for CUDA image
+        if: ${{ matrix.cuda_version }}
+        run: |
+          SHA="${GITHUB_SHA::7}"
+          IFS=,
+          for tag in $(echo ${{ matrix.cuda_version }},${{ matrix.extra_tags }}); do
+            if [ -n $tag ]; then
+              echo "${REGISTRY}/${REPO}:cuda${tag}" >> .tags
+              echo "${REGISTRY}/${REPO}:cuda${tag}.${SHA}" >> .tags
+            fi
+          done
+          echo "EXTRA_TAGS<<EOF" >> $GITHUB_ENV
+          cat .tags >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+      - name: Build tags for non-CUDA image
+        # matrix.extra_tags is required
+        if: ${{ !matrix.cuda_version }}
+        run: |
+          SHA="${GITHUB_SHA::7}"
+          IFS=,
+          for tag in $(echo ${{ matrix.extra_tags }}); do
+            if [ -n $tag ]; then
+              echo "${REGISTRY}/${REPO}:${tag}" >> .tags
+              echo "${REGISTRY}/${REPO}:${tag}.${SHA}" >> .tags
+            fi
+          done
+          if [ -f .tags ]; then
+            echo "EXTRA_TAGS<<EOF" >> $GITHUB_ENV
+            cat .tags >> $GITHUB_ENV
+            echo "EOF" >> $GITHUB_ENV
+          fi
+      - name: Build
+        if: ${{ !env.ACT && !fromJSON(github.event.inputs.is_matrix_test) && env.EXTRA_TAGS }}
+        uses: docker/build-push-action@v3
+        with:
+          context: ./CTR_WORKSPACE
+          file: ${{ matrix.dockerfile }}
+          push: ${{ fromJSON(github.event.inputs.is_push_to_ghcr) }}
+          tags: ${{ env.EXTRA_TAGS }}
+          build-args: |
+            BASE_UBUNTU=${{ matrix.base_ubuntu }}
+            CUDA_VER=${{ matrix.cuda_version }}

--- a/.github/workflows/ctr_workspace.yml
+++ b/.github/workflows/ctr_workspace.yml
@@ -111,3 +111,4 @@ jobs:
           build-args: |
             BASE_UBUNTU=${{ matrix.base_ubuntu }}
             CUDA_VER=${{ matrix.cuda_version }}
+            CUDNN_VER=${{ matrix.cudnn_version }}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,1 @@
+tabWidth: 2

--- a/CTR_WORKSPACE/targets_matrix.json
+++ b/CTR_WORKSPACE/targets_matrix.json
@@ -4,54 +4,63 @@
       "dockerfile": "./CTR_WORKSPACE/ws.dockerfile",
       "extra_tags": "22.04",
       "cuda_version": "",
+      "cudnn_version": null,
       "base_ubuntu": "22.04"
     },
     {
       "dockerfile": "./CTR_WORKSPACE/ws.cuda.dockerfile",
       "extra_tags": "11.0",
       "cuda_version": "11.0.3",
+      "cudnn_version": "cudnn8",
       "base_ubuntu": "20.04"
     },
     {
       "dockerfile": "./CTR_WORKSPACE/ws.cuda.dockerfile",
       "extra_tags": "11.1",
       "cuda_version": "11.1.1",
+      "cudnn_version": "cudnn8",
       "base_ubuntu": "20.04"
     },
     {
       "dockerfile": "./CTR_WORKSPACE/ws.cuda.dockerfile",
       "extra_tags": "11.2",
       "cuda_version": "11.2.2",
+      "cudnn_version": "cudnn8",
       "base_ubuntu": "20.04"
     },
     {
       "dockerfile": "./CTR_WORKSPACE/ws.cuda.dockerfile",
       "extra_tags": "",
       "cuda_version": "11.3.0",
+      "cudnn_version": "cudnn8",
       "base_ubuntu": "20.04"
     },
     {
       "dockerfile": "./CTR_WORKSPACE/ws.cuda.dockerfile",
       "extra_tags": "11.3",
       "cuda_version": "11.3.1",
+      "cudnn_version": "cudnn8",
       "base_ubuntu": "20.04"
     },
     {
       "dockerfile": "./CTR_WORKSPACE/ws.cuda.dockerfile",
       "extra_tags": "11.5",
       "cuda_version": "11.5.2",
+      "cudnn_version": "cudnn8",
       "base_ubuntu": "20.04"
     },
     {
       "dockerfile": "./CTR_WORKSPACE/ws.cuda.dockerfile",
       "extra_tags": "11.7",
       "cuda_version": "11.7.1",
+      "cudnn_version": "cudnn8",
       "base_ubuntu": "22.04"
     },
     {
       "dockerfile": "./CTR_WORKSPACE/ws.cuda.dockerfile",
       "extra_tags": "11.8",
       "cuda_version": "11.8.0",
+      "cudnn_version": "cudnn8",
       "base_ubuntu": "22.04"
     }
   ]

--- a/CTR_WORKSPACE/targets_matrix.json
+++ b/CTR_WORKSPACE/targets_matrix.json
@@ -8,18 +8,6 @@
     },
     {
       "dockerfile": "./CTR_WORKSPACE/ws.cuda.dockerfile",
-      "extra_tags": "",
-      "cuda_version": "10.1",
-      "base_ubuntu": "18.04"
-    },
-    {
-      "dockerfile": "./CTR_WORKSPACE/ws.cuda.dockerfile",
-      "extra_tags": "",
-      "cuda_version": "10.2",
-      "base_ubuntu": "18.04"
-    },
-    {
-      "dockerfile": "./CTR_WORKSPACE/ws.cuda.dockerfile",
       "extra_tags": "11.0",
       "cuda_version": "11.0.3",
       "base_ubuntu": "20.04"
@@ -28,18 +16,6 @@
       "dockerfile": "./CTR_WORKSPACE/ws.cuda.dockerfile",
       "extra_tags": "11.1",
       "cuda_version": "11.1.1",
-      "base_ubuntu": "20.04"
-    },
-    {
-      "dockerfile": "./CTR_WORKSPACE/ws.cuda.dockerfile",
-      "extra_tags": "",
-      "cuda_version": "11.2.0",
-      "base_ubuntu": "20.04"
-    },
-    {
-      "dockerfile": "./CTR_WORKSPACE/ws.cuda.dockerfile",
-      "extra_tags": "",
-      "cuda_version": "11.2.1",
       "base_ubuntu": "20.04"
     },
     {
@@ -62,18 +38,6 @@
     },
     {
       "dockerfile": "./CTR_WORKSPACE/ws.cuda.dockerfile",
-      "extra_tags": "",
-      "cuda_version": "11.5.0",
-      "base_ubuntu": "20.04"
-    },
-    {
-      "dockerfile": "./CTR_WORKSPACE/ws.cuda.dockerfile",
-      "extra_tags": "",
-      "cuda_version": "11.5.1",
-      "base_ubuntu": "20.04"
-    },
-    {
-      "dockerfile": "./CTR_WORKSPACE/ws.cuda.dockerfile",
       "extra_tags": "11.5",
       "cuda_version": "11.5.2",
       "base_ubuntu": "20.04"
@@ -92,4 +56,3 @@
     }
   ]
 }
-

--- a/CTR_WORKSPACE/targets_matrix.json
+++ b/CTR_WORKSPACE/targets_matrix.json
@@ -30,13 +30,6 @@
     },
     {
       "dockerfile": "./CTR_WORKSPACE/ws.cuda.dockerfile",
-      "extra_tags": "",
-      "cuda_version": "11.3.0",
-      "cudnn_version": "cudnn8",
-      "base_ubuntu": "20.04"
-    },
-    {
-      "dockerfile": "./CTR_WORKSPACE/ws.cuda.dockerfile",
       "extra_tags": "11.3",
       "cuda_version": "11.3.1",
       "cudnn_version": "cudnn8",

--- a/CTR_WORKSPACE/targets_matrix.json
+++ b/CTR_WORKSPACE/targets_matrix.json
@@ -2,10 +2,10 @@
   "include": [
     {
       "dockerfile": "./CTR_WORKSPACE/ws.dockerfile",
-      "extra_tags": "22.04",
+      "extra_tags": "24.04",
       "cuda_version": "",
       "cudnn_version": null,
-      "base_ubuntu": "22.04"
+      "base_ubuntu": "24.04"
     },
     {
       "dockerfile": "./CTR_WORKSPACE/ws.cuda.dockerfile",

--- a/CTR_WORKSPACE/targets_matrix.json
+++ b/CTR_WORKSPACE/targets_matrix.json
@@ -55,6 +55,20 @@
       "cuda_version": "11.8.0",
       "cudnn_version": "cudnn8",
       "base_ubuntu": "22.04"
+    },
+    {
+      "dockerfile": "./CTR_WORKSPACE/ws.cuda.dockerfile",
+      "extra_tags": "12.3",
+      "cuda_version": "12.3.2",
+      "cudnn_version": "cudnn9",
+      "base_ubuntu": "22.04"
+    },
+    {
+      "dockerfile": "./CTR_WORKSPACE/ws.cuda.dockerfile",
+      "extra_tags": "12.4",
+      "cuda_version": "12.4.1",
+      "cudnn_version": "cudnn",
+      "base_ubuntu": "22.04"
     }
   ]
 }

--- a/CTR_WORKSPACE/ws.cuda.dockerfile
+++ b/CTR_WORKSPACE/ws.cuda.dockerfile
@@ -1,5 +1,5 @@
-ARG BASE_UBUNTU=20.04
-ARG CUDA_VER=11.3.1
+ARG BASE_UBUNTU=22.04
+ARG CUDA_VER=11.7.1
 ARG CUDNN_VER=cudnn8
 FROM nvidia/cuda:${CUDA_VER}-${CUDNN_VER}-devel-ubuntu${BASE_UBUNTU}
 LABEL maintainer="MamoruDS <mamoruds.io@gmail.com>"

--- a/CTR_WORKSPACE/ws.cuda.dockerfile
+++ b/CTR_WORKSPACE/ws.cuda.dockerfile
@@ -1,6 +1,7 @@
 ARG BASE_UBUNTU=20.04
 ARG CUDA_VER=11.3.1
-FROM nvidia/cuda:${CUDA_VER}-cudnn8-devel-ubuntu${BASE_UBUNTU}
+ARG CUDNN_VER=cudnn8
+FROM nvidia/cuda:${CUDA_VER}-${CUDNN_VER}-devel-ubuntu${BASE_UBUNTU}
 LABEL maintainer="MamoruDS <mamoruds.io@gmail.com>"
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/CTR_WORKSPACE/ws.dockerfile
+++ b/CTR_WORKSPACE/ws.dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_UBUNTU=22.04
+ARG BASE_UBUNTU=24.04
 FROM ubuntu:${BASE_UBUNTU}
 LABEL maintainer="MamoruDS <mamoruds.io@gmail.com>"
 


### PR DESCRIPTION
This PR updates the target matrix:

- remove: Deprecated CUDA targets (images have been removed in upstream docker.io/nvidia/cuda)
- add: CUDA 12.3 and CUDA 12.4 targets
- feat: Define cuDNN version in target matrix for flexible base image naming